### PR TITLE
docs: add gitcgr code graph badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # bunnies
 
 [![Crates.io](https://img.shields.io/crates/v/bunnies)](https://crates.io/crates/bunnies)
+[![gitcgr](https://gitcgr.com/badge/goodvibs/bunnies.svg)](https://gitcgr.com/goodvibs/bunnies)
 
 A fast chess library for chess engines. **Currently in alpha**.
 


### PR DESCRIPTION
Adds a [gitcgr](https://gitcgr.com) badge to the README showing code graph statistics for this repository.

**Badge preview:**

[![gitcgr](https://gitcgr.com/badge/goodvibs/bunnies.svg)](https://gitcgr.com/goodvibs/bunnies)

---

[gitcgr.com](https://gitcgr.com) visualizes any GitHub repo as an interactive code graph — just change `hub` to `cgr` in the URL.

Generated automatically by [gitcgr](https://gitcgr.com).